### PR TITLE
Patch Notes for **GHRD for Agilex 3 FPGA C-Series 26.1**

### DIFF
--- a/a3cw135-devkit-oobe/baseline/software/yocto_linux/kas.yml
+++ b/a3cw135-devkit-oobe/baseline/software/yocto_linux/kas.yml
@@ -24,7 +24,7 @@ repos:
     branch: scarthgap
   meta-altera-fpga:
     url: https://github.com/altera-fpga/meta-altera-fpga.git
-    commit: eb26020e7020d39fed948c29c115a7fb7a9841ed
+    tag: QPDS26.1_p1_REL_GSRD_PR
     layers:
       meta-altera-bsp:
       meta-altera-platform:

--- a/a3cw135-devkit-oobe/baseline/software/yocto_linux/kas_build.sh
+++ b/a3cw135-devkit-oobe/baseline/software/yocto_linux/kas_build.sh
@@ -61,7 +61,7 @@ if [ ! -d "venv" ]; then
     echo "Creating virtual environment..."
     python3 -m venv --system-site-packages venv
     venv/bin/pip install $PIP_PROXY --no-cache-dir --timeout 90 --trusted-host pypi.org --trusted-host files.pythonhosted.org --upgrade pip
-    venv/bin/pip install $PIP_PROXY --no-cache-dir --timeout 90 --trusted-host pypi.org --trusted-host files.pythonhosted.org kas
+    venv/bin/pip install $PIP_PROXY --no-cache-dir --timeout 90 --trusted-host pypi.org --trusted-host files.pythonhosted.org kas==5.2
     venv/bin/pip install $PIP_PROXY --no-cache-dir --timeout 90 --trusted-host pypi.org --trusted-host files.pythonhosted.org kconfiglib
 fi
 

--- a/a3cw135-devkit-oobe/baseline/software/yocto_linux_mainline/kas.yml
+++ b/a3cw135-devkit-oobe/baseline/software/yocto_linux_mainline/kas.yml
@@ -33,7 +33,7 @@ repos:
     branch: whinlatter
   meta-altera-fpga:
     url: https://github.com/altera-fpga/meta-altera-fpga.git
-    commit: 3001dcafbc8860fb95c081e2966ab22edc77f985
+    tag: rel_whinlatter_26.06.01_pr
     layers:
       meta-altera-bsp:
       meta-altera-platform:

--- a/a3cw135-devkit-oobe/baseline/software/yocto_linux_mainline/kas_build.sh
+++ b/a3cw135-devkit-oobe/baseline/software/yocto_linux_mainline/kas_build.sh
@@ -61,7 +61,7 @@ if [ ! -d "venv" ]; then
     echo "Creating virtual environment..."
     python3 -m venv --system-site-packages venv
     venv/bin/pip install $PIP_PROXY --no-cache-dir --timeout 90 --trusted-host pypi.org --trusted-host files.pythonhosted.org --upgrade pip
-    venv/bin/pip install $PIP_PROXY --no-cache-dir --timeout 90 --trusted-host pypi.org --trusted-host files.pythonhosted.org kas
+    venv/bin/pip install $PIP_PROXY --no-cache-dir --timeout 90 --trusted-host pypi.org --trusted-host files.pythonhosted.org kas==5.2
     venv/bin/pip install $PIP_PROXY --no-cache-dir --timeout 90 --trusted-host pypi.org --trusted-host files.pythonhosted.org kconfiglib
 fi
 


### PR DESCRIPTION
## Patch Information:
Quartus Version: 26.1 Build 110 03/26/2026 SC Pro Edition
Tag: QPDS26.1_p1_REL_GSRD_PR
Build: socfpga_ghrd_lth_base/26.1/927

## Issues Resolved
- Switch STREAM source to GitHub mirror. The cs.virginia.edu site no longer hosts the STREAM content, causing SRC_URI fetch failures. Update the source to the GitHub mirror (jeffhammond/STREAM.git), which provides equivalent content.
- Pin kas to v5.2 in kas_build.sh for QPDS26.1_p1_REL_GSRD_PR. Version 5.2 of kas was used to validate QPDS26.1_p1_REL_GSRD_PR. Explicitly pinning this version ensures reproducible builds and prevents potential issues from future kas updates.